### PR TITLE
Fix segmentation fault in loop of std map

### DIFF
--- a/markoviancc.cc
+++ b/markoviancc.cc
@@ -230,7 +230,9 @@ void MarkovianCC::onACK(int ack,
   bool reduce = false;
   if (unacknowledged_packets.count(seq_num) != 0) {
     int tmp_seq_num = -1;
-    for (auto x : unacknowledged_packets) {
+    auto iter = unacknowledged_packets.begin();
+    while (iter != unacknowledged_packets.end()){
+      auto x = *iter;
       assert(tmp_seq_num <= x.first);
       tmp_seq_num = x.first;
       if (x.first > seq_num)
@@ -245,7 +247,7 @@ void MarkovianCC::onACK(int ack,
         pkt_lost = true;
         reduce |= reduce_on_loss.update(true, cur_time, rtt_window.get_latest_rtt());
       }
-      unacknowledged_packets.erase(x.first);
+      iter = unacknowledged_packets.erase(iter);
     }
   }
   if (pkt_lost) {


### PR DESCRIPTION
Hi Venkat,

I found a segmentation fault error when running the sender. The error was caught by systemd-coredump and the backtrace message is:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f292506bd33 in std::_Rb_tree_increment(std::_Rb_tree_node_base*) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb) bt
#0  0x00007f292506bd33 in std::_Rb_tree_increment(std::_Rb_tree_node_base*) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x0000559ef81c9148 in std::_Rb_tree_iterator<std::pair<int const, MarkovianCC::PacketData> >::operator++ (this=<synthetic pointer>)
    at /usr/include/c++/9/bits/stl_tree.h:285
#2  MarkovianCC::onACK (this=this@entry=0x7ffdf96e3ac0, ack=1,
    receiver_timestamp=receiver_timestamp@entry=3761.406348,
    sent_time=sent_time@entry=0.022453000000000001, delta_class=delta_class@entry=-1)
    at markoviancc.cc:233
#3  0x0000559ef81d41f3 in CTCP<MarkovianCC>::send_data (this=0x7ffdf96e3ac0,
    flow_size=flow_size@entry=60000, byte_switched=byte_switched@entry=false,
    flow_id=flow_id@entry=0, src_id=src_id@entry=130100554) at ctcp.hh:292
#4  0x0000559ef81d49ef in TrafficGenerator<CTCP<MarkovianCC> >::send_data (
    this=this@entry=0x7ffdf96e3360, seed=seed@entry=484065355, id=id@entry=130100554)
    at traffic-generator.hh:95
#5  0x0000559ef81ba901 in TrafficGenerator<CTCP<MarkovianCC> >::spawn_senders (
    num_senders=1, this=0x7ffdf96e3360) at traffic-generator.hh:115
#6  main (argc=<optimized out>, argv=<optimized out>) at sender.cc:155
```
My g++ version is 9.4.0 and the OS is Ubuntu 18.04.5 LTS. 

I changed to loop by iterator and found the problem solved. 

